### PR TITLE
Correct Documentation to work with modules expected/required parameters

### DIFF
--- a/module_documentation/arubaoss/arubaoss_tacacs_profile.md
+++ b/module_documentation/arubaoss/arubaoss_tacacs_profile.md
@@ -20,9 +20,13 @@ Description: "This implements rest apis which can be used to configure TACACS Se
     global_auth_key
         description: Authentication key
         required: False
-    server_ip
+    ip_address
         description: TACACS Server IP Address
         required: False
+    version
+        description: Tacacs Server IP Version.
+        choices: "IAV_IP_V4" or "IAV_IP_V6"
+        required True if command=config_tacacs_server
     auth_key
         description: Authentication key
         required: False


### PR DESCRIPTION
Correct ip variable to match what the module expects, add "version" (ipv4/ipv6) ... module requires both ip and version be defined.