### PR TITLE
Fix payload for DNS configuration

### DIFF
--- a/aruba_module_installer/library/modules/network/arubaoss/arubaoss_dns.py
+++ b/aruba_module_installer/library/modules/network/arubaoss/arubaoss_dns.py
@@ -123,7 +123,7 @@ def config(module):
     data['dns_domain_names'] = dnsList
 
     # Configure the dns servers
-    for dnsServer in {params['server_1'], params['server_2'], params['server_3'], params['server_4']}:
+    for dnsServer in [params['server_1'], params['server_2'], params['server_3'], params['server_4']]:
         if not dnsServer == "" and dnsServer not in dnsServerList:
             dnsServerList.append(dnsServer)
             server = 'server_' + str(idval)


### PR DESCRIPTION
Both `server` and `version`variables indices are not correctly being generated as looping over a dictionary does not guarantee an ordered iteration.
I have changed from dictionary to list, and now the indexes are good to go. 