### PR TITLE
Typo on arubaoss_traffic_class

### DIFF
--- a/aruba_module_installer/library/modules/network/arubaoss/arubaoss_traffic_class.py
+++ b/aruba_module_installer/library/modules/network/arubaoss/arubaoss_traffic_class.py
@@ -122,7 +122,7 @@ options:
             - Tos value
         required: false
         choices: 0, 2, 4, 8
-    sequece_no:
+    sequence_no:
         description:
             - Sequence number for the traffic class configured
         required: false


### PR DESCRIPTION
Patch typo on Ansible Documentation : `sequece_no` -> `sequence_no`