### PR TITLE
Check Ansible vers. using packaging.version.parse

### DIFF
--- a/aruba_module_installer/aruba_module_installer.py
+++ b/aruba_module_installer/aruba_module_installer.py
@@ -22,6 +22,7 @@ from os.path import dirname, realpath, exists, isdir
 from os import remove
 from sys import exit
 from re import search
+from packaging import version
 import errno
 
 
@@ -154,7 +155,7 @@ def find_module_path():
         re_path = re_path.groupdict()['path']
 
         # Validate Ansible version is supported
-        if '2.5' <= re_version <= '2.9.9':
+        if version.parse('2.5') <= version.parse(re_version) <= version.parse('2.9.9'):
             return re_path+'/'
         else:
             exit(COLORRED.format('There was an issue with your '


### PR DESCRIPTION
Allows to check Ansible version if Ansible version > `2.9`. Otherwise, Ansible version `2.10` is considered to be < to `2.9`.

This is a prerequisites to fix https://github.com/aruba/aruba-ansible-modules/issues/121

Signed-off-by: Mauvais Joueur <mauvaisjouer+github@sud-ouest.org>